### PR TITLE
add pytest-cov dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ numpy = "^1.22.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"
+pytest-cov = "^3.0.0"
 Sphinx = "^4.4.0"
 myst-nb = "^0.13.1"
 sphinx-autoapi = "^1.8.4"


### PR DESCRIPTION
attempting to fix ci-cd pytest failure